### PR TITLE
fix atom:link so users can jump to the web site after reading good news

### DIFF
--- a/modules/feeds.xql
+++ b/modules/feeds.xql
@@ -13,7 +13,7 @@ declare function local:get-content($entry as element(atom:entry)) {
             <atom:content type="{if ($content/@type = 'markdown') then 'html' else 'xhtml'}">
             { atomic:fix-xhtml-namespace(atomic:get-content($content, true())) }
             </atom:content>,
-            <atom:link type="blog" href="{util:collection-name($entry)}"/>
+            <atom:link type="blog" href="{config:feed-url-from-entry($entry)}"/>
             
         }
 };


### PR DESCRIPTION
Yes I failed to join eXist-db web site reading the good St. Valentines Day's news.