### PR TITLE
[bugfix] Replace sequence() with empty-sequence()

### DIFF
--- a/modules/login.xql
+++ b/modules/login.xql
@@ -45,7 +45,7 @@ import module namespace plogin="http://exist-db.org/xquery/persistentlogin"
     @param $asDba  if true, require the user to be a member of the dba administrators group
 :)
 declare function login:set-user($domain as xs:string, $path as xs:string?, $maxAge as xs:dayTimeDuration?, $asDba as xs:boolean,
-    $onLogin as function(*)) as empty() {
+    $onLogin as function(*)) as empty-sequence() {
     let $userParam := request:get-parameter("user", ())
     let $loginDomain := request:get-parameter("domain", ())
     let $user :=
@@ -78,7 +78,7 @@ declare function login:set-user($domain as xs:string, $path as xs:string?, $maxA
 (:~
     Same as login:set-user#4 but $path set to the default (use context path).
 :)
-declare function login:set-user($domain as xs:string, $maxAge as xs:dayTimeDuration?, $asDba as xs:boolean, $onLogin as function(*)) as empty() {
+declare function login:set-user($domain as xs:string, $maxAge as xs:dayTimeDuration?, $asDba as xs:boolean, $onLogin as function(*)) as empty-sequence() {
     login:set-user($domain, (), $maxAge, $asDba, $onLogin)
 };
 
@@ -104,12 +104,12 @@ declare %private function login:callback($newToken as xs:string?, $user as xs:st
 };
 
 declare %private function login:get-credentials($domain as xs:string, $path as xs:string?, $token as xs:string, $asDba as xs:boolean,
-    $onLogin as function(*)) as empty() {
+    $onLogin as function(*)) as empty-sequence() {
     plogin:login($token, login:callback(?, ?, ?, ?, $domain, $path, $asDba, $onLogin))
 };
 
 declare %private function login:create-login-session($domain as xs:string, $path as xs:string?, $user as xs:string, $password as xs:string,
-    $maxAge as xs:dayTimeDuration?, $asDba as xs:boolean, $onLogin as function(*)) as empty() {
+    $maxAge as xs:dayTimeDuration?, $asDba as xs:boolean, $onLogin as function(*)) as empty-sequence() {
     if (exists($maxAge)) then (
         plogin:register($user, $password, $maxAge, login:callback(?, ?, ?, ?, $domain, $path, $asDba, $onLogin)),
         session:invalidate()
@@ -117,7 +117,7 @@ declare %private function login:create-login-session($domain as xs:string, $path
         login:fallback-to-session($domain, $user, $password, $asDba)
 };
 
-declare %private function login:clear-credentials($token as xs:string?, $domain as xs:string, $path as xs:string?) as empty() {
+declare %private function login:clear-credentials($token as xs:string?, $domain as xs:string, $path as xs:string?) as empty-sequence() {
     response:set-cookie($domain, "deleted", xs:dayTimeDuration("-P1D"), false(), (), 
         if (exists($path)) then $path else request:get-context-path()),
     if ($token and $token != "deleted") then


### PR DESCRIPTION
These changes are needed to make this run on newer version of eXist-db. I had to make these changes manually on www.exist-db.org after deploying eXist 4.1.0.